### PR TITLE
Allow arbitrary system sample rates

### DIFF
--- a/nessers-main/src/audio.rs
+++ b/nessers-main/src/audio.rs
@@ -8,6 +8,7 @@ pub struct AudioDevice {
   pub stream: cpal::Stream,
   pub min_buffer_size: usize,
   pub max_buffer_size: usize,
+  pub sample_rate: u32,
 }
 
 impl AudioDevice {
@@ -16,13 +17,8 @@ impl AudioDevice {
     let device = host.default_output_device().unwrap();
     println!("Output device: {}", device.name().unwrap());
 
-    // Force 44.1kHz
-    let config = device
-      .supported_output_configs()
-      .unwrap()
-      .next()
-      .unwrap()
-      .with_sample_rate(cpal::SampleRate(44100));
+    let config = device.default_output_config().unwrap();
+    let sample_rate = config.sample_rate().0;
 
     let buffer_size = config.buffer_size().clone();
     println!("Default output config: {:?}", config);
@@ -37,6 +33,7 @@ impl AudioDevice {
       stream,
       min_buffer_size: min_buffer_size(&buffer_size),
       max_buffer_size: max_buffer_size(&buffer_size),
+      sample_rate,
     }
   }
 }

--- a/nessers-main/src/main.rs
+++ b/nessers-main/src/main.rs
@@ -83,7 +83,13 @@ fn main() -> Result<(), Error> {
 
   let mut breakpoints_enabled = true;
 
+  // I could probably abstract some of this...
+  let (sample_tx, sample_rx) = mpsc::channel();
+  let audio_device = AudioDevice::init(sample_rx);
+  audio_device.stream.pause().unwrap();
+
   let mut nes = match Nes::new(
+    audio_device.sample_rate as f32,
     &args.arg_rom,
     "nessers-main/src/test_fixtures/ntscpalette.pal",
   ) {
@@ -100,10 +106,6 @@ fn main() -> Result<(), Error> {
   nes.reset();
   nes.step();
 
-  // I could probably abstract some of this...
-  let (sample_tx, sample_rx) = mpsc::channel();
-  let audio_device = AudioDevice::init(sample_rx);
-  audio_device.stream.pause().unwrap();
   let min_audio_buffer_size = audio_device.min_buffer_size;
   let max_audio_buffer_size = audio_device.max_buffer_size;
 

--- a/nessers-main/src/nes.rs
+++ b/nessers-main/src/nes.rs
@@ -36,7 +36,7 @@ pub struct Nes {
 }
 
 impl Nes {
-  pub fn new(cart_filename: &str, palette_filename: &str) -> Result<Nes, &'static str> {
+  pub fn new(system_sample_rate: f32, cart_filename: &str, palette_filename: &str) -> Result<Nes, &'static str> {
     let cpu = Cpu::new();
 
     // 2K internal RAM, mirrored to 8K
@@ -47,7 +47,7 @@ impl Nes {
     let ppu = Ppu::new(Palette::from_file(palette_filename)?);
     let ppu_registers_mirror = Mirror::new(0x2000, 8 * 1024);
 
-    let apu = Apu::new();
+    let apu = Apu::new(system_sample_rate);
 
     let cart = Cart::from_file(cart_filename)?;
 


### PR DESCRIPTION
Previously had 44100hz hard-coded as the system sample rate. Now just uses the system's default sample rate and adjusts APU timing accordingly.